### PR TITLE
Add a note about unblocking the installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,17 @@ This is an _unofficial_ port of [Nord](https://www.nordtheme.com/) to Windows Te
 
 ### Easy Install
 
-Run the `install.ps1` powershell script to install the colorscheme via [Windows Terminal JSON Fragments](https://docs.microsoft.com/en-us/windows/terminal/json-fragment-extensions#where-to-place-the-json-fragment-files)
+Run the `install.ps1` PowerShell script to install the colorscheme via [Windows Terminal JSON Fragments](https://docs.microsoft.com/en-us/windows/terminal/json-fragment-extensions#where-to-place-the-json-fragment-files)
+
+> **Note**  
+> To allow the execution of the installation script without having to relax the [Execution Policy][ps-execpolicy] of the entire system, you can unblock the `install.ps1` file using the [Unblock-File][ps-unblockfile] PowerShell cmdlet.
+>
+> ```powershell
+> Unblock-File .\install.ps1
+> ```
+
+[ps-execpolicy]: https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.security/set-executionpolicy?view=powershell-7.2
+[ps-unblockfile]: https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/unblock-file?view=powershell-7.2
 
 ### Manual
 


### PR DESCRIPTION
By default, PowerShell doesn't allow running scripts without a trusted signature downloaded from the internet.

This PR shows users how to unblock the script in a safe manner to be able to run it.